### PR TITLE
Perhaps a bit more Spark 2.0?

### DIFF
--- a/solutions/spark-streaming-kafka-direct/src/main/scala/StreamingKafkaDirectApp.scala
+++ b/solutions/spark-streaming-kafka-direct/src/main/scala/StreamingKafkaDirectApp.scala
@@ -1,14 +1,14 @@
 import java.util.concurrent.{ExecutorService, Executors}
 
 import org.apache.log4j.{Level, LogManager}
-import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 
 object StreamingKafkaDirectApp extends App {
 
   LogManager.getRootLogger.setLevel(Level.INFO)
 
-  val sc = SparkContext.getOrCreate
+  val sc = SparkSession.builder().getOrCreate().sparkContext
   val ssc = new StreamingContext(sc, Seconds(10))
   try {
     import org.apache.spark.streaming.kafka010._


### PR DESCRIPTION
Beyond Spark 2.0 users are advised to use `SparkSession` for building Spark Apps. I've changed the line in Spark Streaming with Kafka example where `SparkContext` is retrieved from `SparkSession` - making the whole `import` block much nicer.